### PR TITLE
Fixing bug with srray to string method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+*.DS_Store

--- a/src/Paper_submission_code/Data_Formatting.py
+++ b/src/Paper_submission_code/Data_Formatting.py
@@ -13,7 +13,7 @@ class Data_formatting:
         that looks like 110...010, e.g. of length 9 and losing all the middle data. This function appears to work now, but  it is plausible that it is buggy in some unknown way.
         """
         #turn array to string - keeps [] and spaces and commas
-        string_version = str(list(array))
+        string_version = str(array.tolist())
         #remove spaces
         spaces_removed = string_version.replace(" ", "")
         commas_removed = spaces_removed.replace(",", "")

--- a/src/Paper_submission_code/Data_Formatting.py
+++ b/src/Paper_submission_code/Data_Formatting.py
@@ -12,18 +12,7 @@ class Data_formatting:
         Notes: The function turns the array to a list then a string - if you call str(array), once the array is too long, you get an output
         that looks like 110...010, e.g. of length 9 and losing all the middle data. This function appears to work now, but  it is plausible that it is buggy in some unknown way.
         """
-        #turn array to string - keeps [] and spaces and commas
-        string_version = str(array.tolist())
-        #remove spaces
-        spaces_removed = string_version.replace(" ", "")
-        commas_removed = spaces_removed.replace(",", "")
-        #removed brackets
-        left_removed = commas_removed.lstrip("[")
-        right_removed = left_removed.rstrip("]")
-        #return right_removed
-        #there is an issue where long enough arrays get line breaks not removed by removing spaces. this removes those too.
-        spaces_re_removed = right_removed.replace("\n", "")
-        return spaces_re_removed
+        return ''.join(map(str, array))
     
     
     @staticmethod

--- a/src/Paper_submission_code/randomness_testsuite/RunTest.py
+++ b/src/Paper_submission_code/randomness_testsuite/RunTest.py
@@ -18,8 +18,8 @@ class RunTest:
         expected for a random sequence. In particular, this test determines whether the
         oscillation between such zeros and ones is too fast or too slow.
 
-        :param      binary_data:        The seuqnce of bit being tested
-        :param      verbose             True to display the debug messgae, False to turn off debug message
+        :param      binary_data:        The sequence of bit being tested
+        :param      verbose             True to display the debug message, False to turn off debug message
         :return:    (p_value, bool)     A tuple which contain the p_value and result of frequency_test(True or False)
         """
         one_count = 0
@@ -73,7 +73,7 @@ class RunTest:
         longest run of zeroes. Therefore, only a test for ones is necessary.
 
         :param      binary_data:        The sequence of bits being tested
-        :param      verbose             True to display the debug messgae, False to turn off debug message
+        :param      verbose             True to display the debug message, False to turn off debug message
         :return:    (p_value, bool)     A tuple which contain the p_value and result of frequency_test(True or False)
         """
         length_of_binary_data = len(binary_data)

--- a/src/Paper_submission_code/randomness_testsuite/RunTest.py
+++ b/src/Paper_submission_code/randomness_testsuite/RunTest.py
@@ -1,9 +1,9 @@
 from math import fabs as fabs
 from math import floor as floor
 from math import sqrt as sqrt
+from numpy import zeros as zeros
 from scipy.special import erfc as erfc
 from scipy.special import gammaincc as gammaincc
-from scipy import zeros as zeros
 
 class RunTest:
 

--- a/src/Paper_submission_code/randomness_testsuite/RunTest_Q.py
+++ b/src/Paper_submission_code/randomness_testsuite/RunTest_Q.py
@@ -18,8 +18,8 @@ class RunTest_Q:
         expected for a random sequence. In particular, this test determines whether the
         oscillation between such zeros and ones is too fast or too slow.
 
-        :param      binary_data:        The seuqnce of bit being tested
-        :param      verbose             True to display the debug messgae, False to turn off debug message
+        :param      binary_data:        The sequence of bit being tested
+        :param      verbose             True to display the debug message, False to turn off debug message
         :return:    (p_value, bool)     A tuple which contain the p_value and result of frequency_test(True or False)
         """
         one_count = 0
@@ -76,7 +76,7 @@ class RunTest_Q:
         longest run of zeroes. Therefore, only a test for ones is necessary.
 
         :param      binary_data:        The sequence of bits being tested
-        :param      verbose             True to display the debug messgae, False to turn off debug message
+        :param      verbose             True to display the debug message, False to turn off debug message
         :return:    (p_value, bool)     A tuple which contain the p_value and result of frequency_test(True or False)
         """
         length_of_binary_data = len(binary_data)

--- a/src/Paper_submission_code/randomness_testsuite/RunTest_Q.py
+++ b/src/Paper_submission_code/randomness_testsuite/RunTest_Q.py
@@ -1,9 +1,9 @@
 from math import fabs as fabs
 from math import floor as floor
 from math import sqrt as sqrt
+from numpy import zeros as zeros
 from scipy.special import erfc as erfc
 from scipy.special import gammaincc as gammaincc
-from scipy import zeros as zeros
 
 class RunTest_Q:
 


### PR DESCRIPTION
In the method Data_formatting.array_to_string() the first conversion of the numpy array into a list is problematic (at least in the newer numpy/python versions). As an example with the array `array = [1 0 1 1]`, when `list(array)` is called it yields something like `[np.int32(1), np.int32(0), np.int32(1), np.int32(1)]`, which will cause an exception down the line.

I had implemented a similar function before for my own work and have this proposed edit. It fixes the bug, assuming the input is indeed an np.array. It also runs a bit faster.

Thanks for the great work!